### PR TITLE
Transform @time field to event_time and time fields

### DIFF
--- a/conf/docker.conf
+++ b/conf/docker.conf
@@ -114,13 +114,25 @@
 
 #### END PARSE Section #####
 
-# Add event_time as kinesis doesn't support @time (Annotations logs only)
+# Add event_time as kinesis doesn't support @time (Annotations logs only) and time so we have consistent time field in all logs
 <filter docker.annotations>
     @type       record_transformer
     enable_ruby true
     <record>
       event_time        ${ record["@time"] != nil ? record["@time"] : "" }
+      time              ${ record["@time"] != nil ? record["@time"] : "" }
     </record>
+    remove_keys ["@time"]
+</filter>
+
+# use time field where @time is logged in the rest of logs/services
+<filter docker.service_name.*>
+    @type       record_transformer
+    enable_ruby true
+    <record>
+       time             ${ record["@time"] != nil ? record["@time"] : record["time"] }
+    </record>
+    remove_keys ["@time"]
 </filter>
 
 # SPLUNK requires two mandatory fields - > event and time. All log data is put in event field, time field is based on epoch format.


### PR DESCRIPTION
We want to have consistent name for logging time and the we
want to use "time". However we will keep event_time as it is
used by the annotations monitoring.