### PR TITLE
Add kernel logs 

### DIFF
--- a/conf/docker.conf
+++ b/conf/docker.conf
@@ -57,11 +57,18 @@
       tag docker.annotations
    </rule>
    
-   # Tag rest of the journald services 
+   # Tag kubelet services 
    <rule>
       key   SYSTEMD_UNIT
       pattern kubelet.service
       tag   docker.service_name.kubelet
+   </rule>
+   
+   # Tag system logs
+   <rule>
+      key   SYSTEMD_UNIT
+      pattern systemd-journald.service
+      tag   docker.service_name.systemd_journald
    </rule>
 
    # Re-route logs to tags that include their service name (for per-service processing)

--- a/conf/docker.conf
+++ b/conf/docker.conf
@@ -57,18 +57,18 @@
       tag docker.annotations
    </rule>
    
-   # Tag kubelet services 
+   # Tag kubelet service logs
    <rule>
       key   SYSTEMD_UNIT
       pattern kubelet.service
       tag   docker.service_name.kubelet
    </rule>
    
-   # Tag system logs
+   # Tag kernel logs
    <rule>
-      key   SYSTEMD_UNIT
-      pattern systemd-journald.service
-      tag   docker.service_name.systemd_journald
+      key   SYSLOG_IDENTIFIER
+      pattern kernel
+      tag docker.service_name.kernel
    </rule>
 
    # Re-route logs to tags that include their service name (for per-service processing)

--- a/conf/systemd.conf
+++ b/conf/systemd.conf
@@ -5,7 +5,7 @@
   @log_level info
   tag docker.source
   # Match only docker.service, kubelet.service, authorized_keys.service, init.scope logs from Journld
-  matches [{"_SYSTEMD_UNIT": ["docker.service", "kubelet.service", "authorized_keys.service", "init.scope"]}]
+  matches [{"_SYSTEMD_UNIT": ["docker.service", "kubelet.service", "authorized_keys.service", "init.scope", "systemd-journald.service"]}]
   path /var/log/journal #default
   #Set time key to unixtime (SPLUNK expected epoc)
   <storage>

--- a/conf/systemd.conf
+++ b/conf/systemd.conf
@@ -5,7 +5,7 @@
   @log_level info
   tag docker.source
   # Match only docker.service, kubelet.service, authorized_keys.service, init.scope logs from Journld
-  matches [{"_SYSTEMD_UNIT": ["docker.service", "kubelet.service", "authorized_keys.service", "init.scope", "systemd-journald.service"]}]
+  matches [{"_SYSTEMD_UNIT": ["docker.service", "kubelet.service", "authorized_keys.service", "init.scope"]}, {"SYSLOG_IDENTIFIER": "kernel"}]
   path /var/log/journal #default
   #Set time key to unixtime (SPLUNK expected epoc)
   <storage>


### PR DESCRIPTION
This step was missed in the past (when we migrated to FluentD). This results in missing logs form OOM pods -> No triggered alerts from Splunk for OOM.